### PR TITLE
Set rpath when building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,16 @@ if(ENABLE_SDL)
 	)
 	target_include_directories(${PROJECT_NAME}.sdl PRIVATE ${SDL_INCLUDES})
 	target_link_libraries(${PROJECT_NAME}.sdl	${COMMON_LIBS} ${SDL_LIBS})
+
+	#### macOS needs rpath set if using a Framework
+	if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ 		if(SDL2_BINDIR MATCHES ".*SDL2\\.framework.*")
+			add_custom_command(
+				TARGET ${PROJECT_NAME}.sdl POST_BUILD
+				COMMAND install_name_tool -add_rpath ${SDL2_FRAMEWORK_PARENT_PATH} ${PROJECT_NAME}.sdl
+			VERBATIM)
+   		endif()
+	endif()
 endif(ENABLE_SDL)
 
 if(ENABLE_WIN)


### PR DESCRIPTION
Greetings. Thank you for your *fantastic* work on quasi88. 

I'd been hacking on it years back with @barbeque but never did much more than force SDL2 to work with macOS. I recently found your fork and and attempted to build on macOS. Making this one small modification fixes a runtime linking issue. I'm not a macOS developer so there may be a better way to set rpath, but this works well enough. 
I also found that macOS users who install the SDL2 Framework from https://libsdl.org will probably need to run: 
xattr -cr /path/to/Framework/SDL2.framework 
or when the binary runs it will fail when accessing the SDL2 Framework itself.